### PR TITLE
Fix directory existence check

### DIFF
--- a/sevenup
+++ b/sevenup
@@ -26,8 +26,8 @@ sade('sevenup <src> <dest>')
 		if (dest.endsWith(path.sep)) dest = dest.slice(0, -1);
 
 		[src, dest].forEach(dir => {
-			if (!fs.existsSync(src) || !fs.statSync(src).isDirectory()) {
-				error(`${src} is not a directory`);
+			if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+				error(`${dir} is not a directory`);
 			}
 		});
 


### PR DESCRIPTION
Hello! 👋 

I noticed the `src`/`dest` directory check wasn't actually using input `dir` at all and was instead double checking the `src` directory. This fixes it up!

Thank you for the awesome library — LAT already cooking up something with it.